### PR TITLE
DM-29251: Dark mode and general UI

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -16,10 +16,6 @@ const StyledFooter = styled.footer`
 
   background-color: var(--rsd-component-footer-background-color);
 
-  a {
-    color: var(--rsd-component-link-reverse-color);
-  }
-
   .content {
     margin: 0 auto;
     max-width: ${ContentMaxWidth};

--- a/components/footer.js
+++ b/components/footer.js
@@ -14,7 +14,11 @@ const StyledFooter = styled.footer`
   margin-right: -50vw;
   margin-top: 0;
 
-  background-color: var(--rsd-color-primary-100);
+  background-color: var(--rsd-component-footer-background-color);
+
+  a {
+    color: var(--rsd-component-link-reverse-color);
+  }
 
   .content {
     margin: 0 auto;
@@ -73,6 +77,7 @@ export default function Footer() {
         </FundingNotice>
         <PartnerLogoContainer>
           <Image
+            className="u-invertable-image"
             src="/construction-agencies.png"
             width="750px"
             height="119px"

--- a/components/header.js
+++ b/components/header.js
@@ -9,8 +9,7 @@ const StyledHeader = styled.header`
   margin: 0;
   padding: 10px;
 
-  background-color: var(--rsd-color-gray-800);
-  color: var(--rsd-color-gray-100);
+  background-color: var(--rsd-component-header-background-color);
 
   display: flex;
   flex-direction: row;

--- a/components/headerNav.js
+++ b/components/headerNav.js
@@ -17,13 +17,13 @@ const StyledNav = styled.nav`
 const NavItem = styled.div`
   margin: 0 1em;
 
-  color: #ffffff;
+  color: var(--rsd-component-header-nav-text-color);
   a {
-    color: #ffffff;
+    color: var(--rsd-component-header-nav-text-color);
   }
 
   a:hover {
-    color: var(--rsd-color-primary-400);
+    color: var(--rsd-component-header-nav-text-hover-color);
   }
 `;
 

--- a/components/hero.js
+++ b/components/hero.js
@@ -12,10 +12,10 @@ const ContentContainer = styled.div`
     padding: 2rem 0;
   }
 
-  color: var(--c-reverse-text);
+  color: var(--c-component-text-reverse-color);
 
   .hero-title {
-    color: var(--rsd-color-gray-000);
+    color: var(--c-component-text-reverse-color);
     margin-top: 1rem;
     margin-bottom: 3rem;
     text-align: center;

--- a/components/hero.js
+++ b/components/hero.js
@@ -34,8 +34,8 @@ const ServiceCardContainer = styled.div`
 const ServiceCard = styled.div`
   min-width: 5rem;
   border-radius: 0.5rem;
-  background-color: #ffffff;
-  color: #111111;
+  background-color: var(--rsd-component-service-card-background-color);
+  color: var(--rsd-component-service-card-text-color);
   padding: 1rem;
 
   .title {

--- a/components/userMenu.js
+++ b/components/userMenu.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Menu, MenuList, MenuButton, MenuLink } from '@reach/menu-button';
 import '@reach/menu-button/styles.css';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { getLogoutUrl } from '../utils/url';
 
@@ -15,6 +16,12 @@ const StyledMenuButton = styled(MenuButton)`
   &:hover {
     color: var(--rsd-component-header-nav-text-hover-color);
   }
+`;
+
+const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
+  margin-left: 0.25em;
+  font-size: 0.8em;
+  opacity: 0.9;
 `;
 
 const StyledMenuList = styled(MenuList)`
@@ -54,7 +61,9 @@ export const UserMenu = ({ loginData, pageUrl }) => {
 
   return (
     <Menu>
-      <StyledMenuButton>{loginData.data.name}</StyledMenuButton>
+      <StyledMenuButton>
+        {loginData.data.name} <StyledFontAwesomeIcon icon="angle-down" />
+      </StyledMenuButton>
       <StyledMenuList>
         <MenuLink href="/auth/tokens">Security tokens</MenuLink>
         <MenuLink href={logoutUrl}>Log out</MenuLink>

--- a/components/userMenu.js
+++ b/components/userMenu.js
@@ -1,21 +1,64 @@
 /* Menu for a user profile and settings, built on @react/menu-button. */
 
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import { Menu, MenuList, MenuButton, MenuLink } from '@reach/menu-button';
 import '@reach/menu-button/styles.css';
 
 import { getLogoutUrl } from '../utils/url';
+
+const StyledMenuButton = styled(MenuButton)`
+  background-color: transparent;
+  color: var(--rsd-component-header-nav-text-color);
+  border: none;
+
+  &:hover {
+    color: var(--rsd-component-header-nav-text-hover-color);
+  }
+`;
+
+const StyledMenuList = styled(MenuList)`
+  font-size: 1rem;
+  background-color: var(--rsd-component-header-nav-menulist-background-color);
+  width: 12rem;
+  border-radius: 0.5rem;
+  // Top margin is related to the triangle; see :before
+  margin-top: 10px;
+  color: var(--rsd-component-header-nav-menulist-text-color);
+  a {
+    color: var(--rsd-component-header-nav-menulist-text-color);
+  }
+
+  &:before {
+    // Make a CSS triangle on the top of the menu
+    content: '';
+    border: 8px solid transparent;
+    border-bottom: 8px solid
+      var(--rsd-component-header-nav-menulist-background-color);
+    position: absolute;
+    display: inline-block;
+    // Top is related to the border size and margin-top of menu list
+    top: -5px;
+    right: 9px;
+    left: auto;
+  }
+
+  [data-reach-menu-item][data-selected] {
+    background: var(--rsd-component-header-nav-menulist-selected-background-color);
+  }
+}
+`;
 
 export const UserMenu = ({ loginData, pageUrl }) => {
   const logoutUrl = getLogoutUrl(pageUrl);
 
   return (
     <Menu>
-      <MenuButton>{loginData.data.name}</MenuButton>
-      <MenuList>
+      <StyledMenuButton>{loginData.data.name}</StyledMenuButton>
+      <StyledMenuList>
         <MenuLink href="/auth/tokens">Security tokens</MenuLink>
         <MenuLink href={logoutUrl}>Log out</MenuLink>
-      </MenuList>
+      </StyledMenuList>
     </Menu>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "ajv": "^7.0.3",
         "js-yaml": "^4.0.0",
         "next": "10.0.5",
+        "next-themes": "^0.0.13-beta.2",
         "normalize.css": "^8.0.1",
         "prop-types": "^15.7.2",
         "react": "17.0.1",
@@ -5987,6 +5988,16 @@
       },
       "optionalDependencies": {
         "sharp": "0.26.3"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.0.13-beta.2",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.0.13-beta.2.tgz",
+      "integrity": "sha512-qnEsA9Or/CsMWJvTraF/MJ5hPsYEL0DRVpyIefiHqYn79JlcH4Aj6yX1FTPq2AE+PWk2O+SSTSBtplh98PVfgA==",
+      "peerDependencies": {
+        "next": "*",
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/next-tick": {
@@ -14841,6 +14852,12 @@
         "webpack": "4.44.1",
         "webpack-sources": "1.4.3"
       }
+    },
+    "next-themes": {
+      "version": "0.0.13-beta.2",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.0.13-beta.2.tgz",
+      "integrity": "sha512-qnEsA9Or/CsMWJvTraF/MJ5hPsYEL0DRVpyIefiHqYn79JlcH4Aj6yX1FTPq2AE+PWk2O+SSTSBtplh98PVfgA==",
+      "requires": {}
     },
     "next-tick": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "squareone",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.35",
+        "@fortawesome/free-solid-svg-icons": "^5.15.3",
+        "@fortawesome/react-fontawesome": "^0.1.14",
         "@lsst-sqre/rubin-style-dictionary": "^0.3.0-beta.3",
         "@reach/menu-button": "^0.12.1",
         "ajv": "^7.0.3",
@@ -446,6 +449,51 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
+      "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz",
+      "integrity": "sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "^1.2.32",
+        "react": ">=16.x"
       }
     },
     "node_modules/@hapi/accept": {
@@ -10197,6 +10245,35 @@
           "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
         }
+      }
+    },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+      "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.35",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
+      "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
+      "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.35"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz",
+      "integrity": "sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==",
+      "requires": {
+        "prop-types": "^15.7.2"
       }
     },
     "@hapi/accept": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@fortawesome/react-fontawesome": "^0.1.14",
-        "@lsst-sqre/rubin-style-dictionary": "^0.3.0-beta.3",
+        "@lsst-sqre/rubin-style-dictionary": "^0.3.0-beta.5",
         "@reach/menu-button": "^0.12.1",
         "ajv": "^7.0.3",
         "js-yaml": "^4.0.0",
@@ -519,9 +519,9 @@
       "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
     },
     "node_modules/@lsst-sqre/rubin-style-dictionary": {
-      "version": "0.3.0-beta.3",
-      "resolved": "https://npm.pkg.github.com/download/@lsst-sqre/rubin-style-dictionary/0.3.0-beta.3/74e23d3a95a0e774b610c81a7af5412631be3f925e0a28ee2012a8f16cbbd210",
-      "integrity": "sha512-1/rTC5/+suujv+Yw/n5CDSoNU2o6OD8VUd7rPZM0kBNwhOAZ/o8hZ0OTCsotlf1I1ak3Q0iSIJMEPi91fuQY5A==",
+      "version": "0.3.0-beta.5",
+      "resolved": "https://npm.pkg.github.com/download/@lsst-sqre/rubin-style-dictionary/0.3.0-beta.5/34b22b95eac0cc9a1fdf904a90ace19a14ffcf7cf64b1d49a20a15eb9fd1fc3d",
+      "integrity": "sha512-9AiFMUfSOzcwdGwNJJOXQOJueDr+grs1ohv4FYlvkcOaxOoFI/EIaDKrsbsO2bKnpt1HG6qcs6vTM2UTq2jG1A==",
       "license": "MIT"
     },
     "node_modules/@next/env": {
@@ -10299,9 +10299,9 @@
       "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
     },
     "@lsst-sqre/rubin-style-dictionary": {
-      "version": "0.3.0-beta.3",
-      "resolved": "https://npm.pkg.github.com/download/@lsst-sqre/rubin-style-dictionary/0.3.0-beta.3/74e23d3a95a0e774b610c81a7af5412631be3f925e0a28ee2012a8f16cbbd210",
-      "integrity": "sha512-1/rTC5/+suujv+Yw/n5CDSoNU2o6OD8VUd7rPZM0kBNwhOAZ/o8hZ0OTCsotlf1I1ak3Q0iSIJMEPi91fuQY5A=="
+      "version": "0.3.0-beta.5",
+      "resolved": "https://npm.pkg.github.com/download/@lsst-sqre/rubin-style-dictionary/0.3.0-beta.5/34b22b95eac0cc9a1fdf904a90ace19a14ffcf7cf64b1d49a20a15eb9fd1fc3d",
+      "integrity": "sha512-9AiFMUfSOzcwdGwNJJOXQOJueDr+grs1ohv4FYlvkcOaxOoFI/EIaDKrsbsO2bKnpt1HG6qcs6vTM2UTq2jG1A=="
     },
     "@next/env": {
       "version": "10.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2696,17 +2696,17 @@
       "integrity": "sha512-4POzwyQ80tkDiBwkxn7IpfzioimrjRSFX1sCQ3pLZsYJ5ERYmwzdq0hZZ3nFP7Z6GtmnSn3xwWDm8FPlMeOoEQ=="
     },
     "node_modules/elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dependencies": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
@@ -12157,17 +12157,17 @@
       "integrity": "sha512-4POzwyQ80tkDiBwkxn7IpfzioimrjRSFX1sCQ3pLZsYJ5ERYmwzdq0hZZ3nFP7Z6GtmnSn3xwWDm8FPlMeOoEQ=="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ajv": "^7.0.3",
     "js-yaml": "^4.0.0",
     "next": "10.0.5",
+    "next-themes": "^0.0.13-beta.2",
     "normalize.css": "^8.0.1",
     "prop-types": "^15.7.2",
     "react": "17.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "*.js": "eslint"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
+    "@fortawesome/react-fontawesome": "^0.1.14",
     "@lsst-sqre/rubin-style-dictionary": "^0.3.0-beta.3",
     "@reach/menu-button": "^0.12.1",
     "ajv": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
-    "@lsst-sqre/rubin-style-dictionary": "^0.3.0-beta.3",
+    "@lsst-sqre/rubin-style-dictionary": "^0.3.0-beta.5",
     "@reach/menu-button": "^0.12.1",
     "ajv": "^7.0.3",
     "js-yaml": "^4.0.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,11 +2,18 @@ import PropTypes from 'prop-types';
 import getConfig from 'next/config';
 import { ThemeProvider } from 'next-themes';
 
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
+import '@fortawesome/fontawesome-svg-core/styles.css';
+
 import 'normalize.css';
 import '@lsst-sqre/rubin-style-dictionary/dist/tokens.css';
 import '../styles/globals.css';
 import { useLogin } from '../hooks/login';
 import Page from '../components/page';
+
+// Add icons to the global Font Awesome library
+library.add(faAngleDown);
 
 function MyApp({ Component, pageProps, baseUrl }) {
   const loginData = useLogin(baseUrl);

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import getConfig from 'next/config';
+import { ThemeProvider } from 'next-themes';
 
 import 'normalize.css';
 import '@lsst-sqre/rubin-style-dictionary/dist/tokens.css';
@@ -11,9 +12,11 @@ function MyApp({ Component, pageProps, baseUrl }) {
   const loginData = useLogin(baseUrl);
   /* eslint-disable react/jsx-props-no-spreading */
   return (
-    <Page loginData={loginData} baseUrl={baseUrl}>
-      <Component {...pageProps} />
-    </Page>
+    <ThemeProvider defaultTheme="system">
+      <Page loginData={loginData} baseUrl={baseUrl}>
+        <Component {...pageProps} />
+      </Page>
+    </ThemeProvider>
   );
   /* eslint-enable react/jsx-props-no-spreading */
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -8,6 +8,7 @@ import '@fortawesome/fontawesome-svg-core/styles.css';
 
 import 'normalize.css';
 import '@lsst-sqre/rubin-style-dictionary/dist/tokens.css';
+import '@lsst-sqre/rubin-style-dictionary/dist/tokens.dark.css';
 import '../styles/globals.css';
 import { useLogin } from '../hooks/login';
 import Page from '../components/page';

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -38,6 +38,15 @@ html {
   --rsd-component-image-invert: 0;
   --rsd-component-service-card-background-color: var(--rsd-color-gray-000);
   --rsd-component-service-card-text-color: var(--rsd-component-text-color);
+  --rsd-component-header-background-color: var(--rsd-color-gray-800);
+  --rsd-component-header-nav-text-color: var(--rsd-color-gray-000);
+  --rsd-component-header-nav-text-hover-color: var(--rsd-color-primary-400);
+  --rsd-component-header-nav-menulist-background-color: var(
+    --rsd-color-gray-000
+  );
+  --rsd-component-header-nav-menulist-selected-background-color: var(
+    --rsd-color-primary-600
+  );
 
   --c-headline: var(--rsd-color-primary-600);
   --c-reverse-text: var(--rsd-color-gray-000);
@@ -92,6 +101,13 @@ img.u-invertable-image {
   --rsd-component-service-card-background-color: var(--rsd-color-gray-800);
   --rsd-component-service-card-text-color: var(
     --rsd-component-text-reverse-color
+  );
+  --rsd-component-header-nav-menulist-background-color: var(
+    --rsd-color-primary-600
+  );
+  --rsd-component-header-nav-menulist-text-color: var(--rsd-color-gray-000);
+  --rsd-component-header-nav-menulist-selected-background-color: var(
+    --rsd-color-primary-700
   );
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -31,6 +31,12 @@ html {
   /*
    * Semantic and component colors
    */
+  --rsd-component-page-background-color: var(--rsd-color-gray-000);
+  --rsd-component-footer-background-color: var(--rsd-color-primary-100);
+  --rsd-component-text-reverse-color: var(--rsd-color-gray-100);
+  --rsd-component-link-reverse-color: var(--rsd-color-blue-500);
+  --rsd-component-image-invert: 0;
+
   --c-headline: var(--rsd-color-primary-600);
   --c-reverse-text: var(--rsd-color-gray-000);
   /*
@@ -49,6 +55,7 @@ body {
     Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
     sans-serif;
   color: var(--rsd-component-text-color);
+  background-color: var(--rsd-component-page-background-color);
 }
 
 h1,
@@ -65,6 +72,23 @@ a:hover {
   color: var(--rsd-color-blue-500);
 }
 
+/*
+ * Images that can be inverted to accomodate dark themes.
+ */
+img.u-invertable-image {
+  filter: invert(var(--rsd-component-image-invert));
+}
+
+/*
+ * Design token overrides for dark theme.
+ */
 [data-theme='dark'] body {
-  color: red;
+  --rsd-component-text-color: var(--rsd-component-text-reverse-color);
+  --rsd-component-page-background-color: var(--rsd-color-gray-900);
+  --rsd-component-footer-background-color: var(--rsd-color-primary-700);
+  --rsd-component-image-invert: 100%;
+}
+
+[data-theme='dark'] a {
+  color: var(--rsd-component-link-reverse-color);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -48,9 +48,6 @@ body {
   font-family: 'Source Sans Pro', -apple-system, BlinkMacSystemFont, Segoe UI,
     Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
     sans-serif;
-}
-
-body {
   color: var(--rsd-component-text-color);
 }
 
@@ -66,4 +63,8 @@ a {
 
 a:hover {
   color: var(--rsd-color-blue-500);
+}
+
+[data-theme='dark'] body {
+  color: red;
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,7 +13,7 @@ html {
 }
 
 /*
- * Disable artifical scaling, but let user zoom if needed.
+ * Disable artificial scaling, but let user zoom if needed.
  * Flexible Typesetting, Tim Brown, ch 2.
  */
 @viewport {
@@ -28,33 +28,7 @@ html {
    */
   font-size: 1.1rem;
 
-  /*
-   * Semantic and component colors
-   */
-  --rsd-component-page-background-color: var(--rsd-color-gray-000);
-  --rsd-component-footer-background-color: var(--rsd-color-primary-100);
-  --rsd-component-text-reverse-color: var(--rsd-color-gray-100);
-  --rsd-component-link-reverse-color: var(--rsd-color-blue-500);
   --rsd-component-image-invert: 0;
-  --rsd-component-service-card-background-color: var(--rsd-color-gray-000);
-  --rsd-component-service-card-text-color: var(--rsd-component-text-color);
-  --rsd-component-header-background-color: var(--rsd-color-gray-800);
-  --rsd-component-header-nav-text-color: var(--rsd-color-gray-000);
-  --rsd-component-header-nav-text-hover-color: var(--rsd-color-primary-400);
-  --rsd-component-header-nav-menulist-background-color: var(
-    --rsd-color-gray-000
-  );
-  --rsd-component-header-nav-menulist-selected-background-color: var(
-    --rsd-color-primary-600
-  );
-
-  --c-headline: var(--rsd-color-primary-600);
-  --c-reverse-text: var(--rsd-color-gray-000);
-  /*
-  * darker than blue-500
-  */
-  --c-link: #146685;
-
   --size-screen-padding-min: 1rem;
 }
 
@@ -71,20 +45,20 @@ body {
 
 h1,
 h2 {
-  color: var(--c-headline);
+  color: var(--rsd-component-text-headline-color);
 }
 
 a {
-  color: var(--c-link);
+  color: var(--rsd-component-text-link-color);
   text-decoration: none;
 }
 
 a:hover {
-  color: var(--rsd-color-blue-500);
+  color: var(--rsd-component-text-link-hover-color);
 }
 
 /*
- * Images that can be inverted to accomodate dark themes.
+ * Images that can be inverted to accommodate dark themes.
  */
 img.u-invertable-image {
   filter: invert(var(--rsd-component-image-invert));
@@ -94,23 +68,5 @@ img.u-invertable-image {
  * Design token overrides for dark theme.
  */
 [data-theme='dark'] body {
-  --rsd-component-text-color: var(--rsd-component-text-reverse-color);
-  --rsd-component-page-background-color: var(--rsd-color-gray-900);
-  --rsd-component-footer-background-color: var(--rsd-color-primary-700);
   --rsd-component-image-invert: 100%;
-  --rsd-component-service-card-background-color: var(--rsd-color-gray-800);
-  --rsd-component-service-card-text-color: var(
-    --rsd-component-text-reverse-color
-  );
-  --rsd-component-header-nav-menulist-background-color: var(
-    --rsd-color-primary-600
-  );
-  --rsd-component-header-nav-menulist-text-color: var(--rsd-color-gray-000);
-  --rsd-component-header-nav-menulist-selected-background-color: var(
-    --rsd-color-primary-700
-  );
-}
-
-[data-theme='dark'] a {
-  color: var(--rsd-component-link-reverse-color);
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -36,6 +36,8 @@ html {
   --rsd-component-text-reverse-color: var(--rsd-color-gray-100);
   --rsd-component-link-reverse-color: var(--rsd-color-blue-500);
   --rsd-component-image-invert: 0;
+  --rsd-component-service-card-background-color: var(--rsd-color-gray-000);
+  --rsd-component-service-card-text-color: var(--rsd-component-text-color);
 
   --c-headline: var(--rsd-color-primary-600);
   --c-reverse-text: var(--rsd-color-gray-000);
@@ -87,6 +89,10 @@ img.u-invertable-image {
   --rsd-component-page-background-color: var(--rsd-color-gray-900);
   --rsd-component-footer-background-color: var(--rsd-color-primary-700);
   --rsd-component-image-invert: 100%;
+  --rsd-component-service-card-background-color: var(--rsd-color-gray-800);
+  --rsd-component-service-card-text-color: var(
+    --rsd-component-text-reverse-color
+  );
 }
 
 [data-theme='dark'] a {


### PR DESCRIPTION
This PR provides significant improvements to the UI:

- Integrates squareone's UI with rubin-style-dictionary's component design tokens
- Integrates with next-themes to implement dark/light mode. Current light or dark mode is based on the user's system UI preference.
- Use font-awesome to provide a downward chevron affordance for the user login menu.

## Screen shots

<img width="266" alt="Screen Shot 2021-03-24 at 5 41 00 PM" src="https://user-images.githubusercontent.com/349384/112549321-009e9080-8d94-11eb-8a58-3b849c5e9072.png">

![localhost_3001 Laptop 2021-03-25 22 03 03](https://user-images.githubusercontent.com/349384/112549558-60953700-8d94-11eb-9a2b-f83161957687.png)

<img width="1015" alt="Screen Shot 2021-03-25 at 6 05 02 PM" src="https://user-images.githubusercontent.com/349384/112549726-a05c1e80-8d94-11eb-9738-52acaf848776.png">
